### PR TITLE
Fixes issue #12 - 2gb Image limitation for gamelists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ Makefile
 CPackConfig.cmake
 CPackSourceConfig.cmake
 *.cbp
+
+# macOS
+.DS_Store

--- a/es-app/src/main.cpp
+++ b/es-app/src/main.cpp
@@ -219,7 +219,13 @@ void onExit()
 	Log::close();
 }
 
+#if WIN32
+#define argc __argc
+#define argv __argv
+int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE prevInstance, LPSTR lpCmdLine, int nShowCmd)
+#else
 int main(int argc, char* argv[])
+#endif
 {
 	srand((unsigned int)time(NULL));
 

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -14,9 +14,12 @@
 #define unlink _unlink
 #define S_ISREG(x) (((x) & S_IFMT) == S_IFREG)
 #define S_ISDIR(x) (((x) & S_IFMT) == S_IFDIR)
+#define stat64 _stat64
+#define lstat64 _lstat64
 #else // _WIN32
 #include <dirent.h>
 #include <unistd.h>
+#define __stat64 stat64
 #endif // _WIN32
 
 namespace Utils
@@ -497,7 +500,7 @@ namespace Utils
 				CloseHandle(hFile);
 			}
 #else // _WIN32
-			struct stat64 info;
+			struct __stat64 info;
 
 			// check if lstat succeeded
 			if(lstat64(path.c_str(), &info) == 0)
@@ -553,7 +556,7 @@ namespace Utils
 		bool exists(const std::string& _path)
 		{
 			std::string path = getGenericPath(_path);
-			struct stat64 info;
+			struct __stat64 info;
 
 			// check if stat succeeded
 			return (stat64(path.c_str(), &info) == 0);
@@ -575,7 +578,7 @@ namespace Utils
 		bool isRegularFile(const std::string& _path)
 		{
 			std::string path = getGenericPath(_path);
-			struct stat64 info;
+			struct __stat64 info;
 
 			// check if stat succeeded
 			if(stat64(path.c_str(), &info) != 0)
@@ -589,7 +592,7 @@ namespace Utils
 		bool isDirectory(const std::string& _path)
 		{
 			std::string path = getGenericPath(_path);
-			struct stat64 info;
+			struct __stat64 info;
 
 			// check if stat succeeded
 			if(stat64(path.c_str(), &info) != 0)
@@ -610,7 +613,7 @@ namespace Utils
 			if((Attributes != INVALID_FILE_ATTRIBUTES) && (Attributes & FILE_ATTRIBUTE_REPARSE_POINT))
 				return true;
 #else // _WIN32
-			struct stat64 info;
+			struct __stat64 info;
 
 			// check if lstat succeeded
 			if(lstat64(path.c_str(), &info) != 0)
@@ -649,8 +652,8 @@ namespace Utils
 		{
 			std::string path1 = getGenericPath(_path1);
 			std::string path2 = getGenericPath(_path2);
-			struct stat64 info1;
-			struct stat64 info2;
+			struct __stat64 info1;
+			struct __stat64 info2;
 
 			// check if stat succeeded
 			if((stat64(path1.c_str(), &info1) != 0) || (stat64(path2.c_str(), &info2) != 0))

--- a/es-core/src/utils/FileSystemUtil.cpp
+++ b/es-core/src/utils/FileSystemUtil.cpp
@@ -497,10 +497,10 @@ namespace Utils
 				CloseHandle(hFile);
 			}
 #else // _WIN32
-			struct stat info;
+			struct stat64 info;
 
 			// check if lstat succeeded
-			if(lstat(path.c_str(), &info) == 0)
+			if(lstat64(path.c_str(), &info) == 0)
 			{
 				resolved.resize(info.st_size);
 				if(readlink(path.c_str(), (char*)resolved.data(), resolved.size()) > 0)
@@ -553,10 +553,10 @@ namespace Utils
 		bool exists(const std::string& _path)
 		{
 			std::string path = getGenericPath(_path);
-			struct stat info;
+			struct stat64 info;
 
 			// check if stat succeeded
-			return (stat(path.c_str(), &info) == 0);
+			return (stat64(path.c_str(), &info) == 0);
 
 		} // exists
 
@@ -575,10 +575,10 @@ namespace Utils
 		bool isRegularFile(const std::string& _path)
 		{
 			std::string path = getGenericPath(_path);
-			struct stat info;
+			struct stat64 info;
 
 			// check if stat succeeded
-			if(stat(path.c_str(), &info) != 0)
+			if(stat64(path.c_str(), &info) != 0)
 				return false;
 
 			// check for S_IFREG attribute
@@ -589,10 +589,10 @@ namespace Utils
 		bool isDirectory(const std::string& _path)
 		{
 			std::string path = getGenericPath(_path);
-			struct stat info;
+			struct stat64 info;
 
 			// check if stat succeeded
-			if(stat(path.c_str(), &info) != 0)
+			if(stat64(path.c_str(), &info) != 0)
 				return false;
 
 			// check for S_IFDIR attribute
@@ -610,10 +610,10 @@ namespace Utils
 			if((Attributes != INVALID_FILE_ATTRIBUTES) && (Attributes & FILE_ATTRIBUTE_REPARSE_POINT))
 				return true;
 #else // _WIN32
-			struct stat info;
+			struct stat64 info;
 
 			// check if lstat succeeded
-			if(lstat(path.c_str(), &info) != 0)
+			if(lstat64(path.c_str(), &info) != 0)
 				return false;
 
 			// check for S_IFLNK attribute
@@ -649,11 +649,11 @@ namespace Utils
 		{
 			std::string path1 = getGenericPath(_path1);
 			std::string path2 = getGenericPath(_path2);
-			struct stat info1;
-			struct stat info2;
+			struct stat64 info1;
+			struct stat64 info2;
 
 			// check if stat succeeded
-			if((stat(path1.c_str(), &info1) != 0) || (stat(path2.c_str(), &info2) != 0))
+			if((stat64(path1.c_str(), &info1) != 0) || (stat64(path2.c_str(), &info2) != 0))
 				return false;
 
 			// check if attributes are identical


### PR DESCRIPTION
Previously, ES was using the stat and lstat functions for file operations such as checking if a file exists when parsing the gamelist.xml files. However, those functions don't support files larger than 2GB. So for example most PS2 games will fail to show metadata.

I replaced those functions with stat64 and lstat64, which support much larger files, and added the appropriate workarounds for cross platform support. I compiled and tested on Windows 10, and compiled (but didn't test as it's a terminal-only VM) on Ubuntu 16.04.

Though I tested on a 64bit system, I built a 32bit executable, so there's no reason this fix shouldn't work on 32bit machines. It appears that these functions are in win32.